### PR TITLE
Fix a Localization Error

### DIFF
--- a/user-photo.php
+++ b/user-photo.php
@@ -668,7 +668,7 @@ add_action('edit_user_profile', 'userphoto_display_selector_fieldset');
 
 function userphoto_add_page() {
 	//if (function_exists('add_options_page'))
-	add_options_page('User Photo', 'User Photo', 8, __FILE__, 'userphoto_options_page');
+	add_options_page( 'User Photo', 'User Photo', 'manage_options', __FILE__, 'userphoto_options_page' );
 }
 add_action('admin_menu', 'userphoto_add_page');
 

--- a/user-photo.php
+++ b/user-photo.php
@@ -74,7 +74,7 @@ $userphoto_prevent_override_avatar = false;
 
 # Load up the localization file if we're using WordPress in a different language
 # Place it in the "localization" folder and name it "user-photo-[value in wp-config].mo"
-load_plugin_textdomain('user-photo', PLUGINDIR . '/user-photo/localization'); #(thanks Pakus)
+load_plugin_textdomain( 'user-photo', false, dirname( plugin_basename( __FILE__ ) ) . '/localization' );
 
 function userphoto__init(){
 	if(get_option('userphoto_override_avatar') && !is_admin())


### PR DESCRIPTION
The ABSPATH-relative include is deprecated as of WP 2.7. Should be set to false and use a plugins-relative include instead.
