### PR TITLE
Replace mysql_escape_string for PHP 7 compatibility

### DIFF
--- a/user-photo.php
+++ b/user-photo.php
@@ -100,7 +100,7 @@ function userphoto_filter_get_avatar($avatar, $id_or_email, $size, $default){
 	if(is_numeric($id_or_email))
 		$userid = (int)$id_or_email;
 	else if(is_string($id_or_email))
-		$userid = (int)$wpdb->get_var("SELECT ID FROM $wpdb->users WHERE user_email = '" . mysql_escape_string($id_or_email) . "'");
+		$userid = (int)$wpdb->get_var($wpdb->prepare("SELECT ID FROM $wpdb->users WHERE user_email = '%s'", $id_or_email));
 	
 	if(!$userid)
 		return $avatar;


### PR DESCRIPTION
The original MySQL extension was removed in PHP 7.0.0, so mysql_escape_string (on line 103) no longer works.  Rather than replace it with mysqli_escape_string, I resolved the issue using $wpdb-prepare() instead.

I'm not sure if this repo is still active (it's a version behind 0.9.6) but I figured I would create a pull request, just in case.  Hope this helps.
